### PR TITLE
Adds concept of New Followers where they are NOT in the past known

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
   "properties": {
+    "clientid": {
+      "description": "Twitch.tv ClientID see https://github.com/justintv/Twitch-API/blob/master/authentication.md",
+      "type": "string",
+      "default": ""
+    },
     "username": {
       "description": "Twitch.tv username",
       "type": "string",
@@ -13,5 +18,5 @@
       "minimum": 30
     }
   },
-  "required": ["username"]
+  "required": ["username", "clientid"]
 }

--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,7 @@ function Followers(nodecg) {
   this.latestNewFollower = nodecg.Replicant('latestNewFollower', { defaultValue: null, persistent: true });
   this.latestFollowers = nodecg.Replicant('lastestFollowers', {defaultValue: [], persistent: true });
   this.username = nodecg.bundleConfig.username;
+  this.clientid = nodecg.bundleConfig.clientid;
   this.pollInterval = nodecg.bundleConfig.pollInterval * 1000;
 
   this._scheduleFollowers();
@@ -14,7 +15,7 @@ function Followers(nodecg) {
 
 Followers.prototype._scheduleFollowers = function() {
   this.nodecg.log.debug('Polling for TwitchTV Followers.');
-  this.request('https://api.twitch.tv/kraken/channels/' + this.username + '/follows?limit=50',
+  this.request('https://api.twitch.tv/kraken/channels/' + this.username + '/follows?limit=50&client_id=' + this.clientid,
     (err, response, body) => {
       if (err) {
         this.nodecg.log.error(err);

--- a/nodecg.json
+++ b/nodecg.json
@@ -1,9 +1,10 @@
 {
-  "name": "bubu-followers",
-  "version": "0.1.0",
+  "name": "node-followers",
+  "version": "0.2.0",
   "nodecgDependency": "~0.6.0",
-  "homepage": "https://github.com/eaceaser/bubu-followers",
+  "homepage": "https://github.com/coolacid/nodecg-followers",
   "authors": [
+    "Jason kendall <coolacid@gmail.com>",
     "Ed Ceaser <ed@tehasdf.com>"
   ],
   "description": "Tracks TwitchTV channel followers for the currently authenticated TwitchAPI user.",

--- a/nodecg.json
+++ b/nodecg.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-followers",
+  "name": "nodecg-followers",
   "version": "0.2.0",
   "nodecgDependency": "~0.6.0",
   "homepage": "https://github.com/coolacid/nodecg-followers",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "^1.6.0"
   },
   "nodecg": {
-    "compatibleRange": "~0.7.0"
+    "compatibleRange": "~0.8.0"
   },
   "repository": "coolacid/nodecg-followers"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "bubu-followers",
+  "name": "nodecg-followers",
   "version": "0.2.0",
-  "homepage": "https://github.com/eaceaser/bubu-followers",
+  "homepage": "https://github.com/coolacid/nodecg-followers",
   "description": "Tracks TwitchTV channel followers. Currently runs in the dashboard.",
-  "author": "Ed Ceaser <ed@tehasdf.com>",
+  "author": "CoolAcid <coolacid@gmail.com>",
   "files": [
     "extension.js"
   ],
@@ -21,5 +21,5 @@
   "nodecg": {
     "compatibleRange": "~0.7.0"
   },
-  "repository": "eaceaser/bubu-followers"
+  "repository": "coolacid/nodecg-followers"
 }


### PR DESCRIPTION
There are times where a spammer will attempt to unfollow, and refollow to get their name mentioned multiple times. 

This PR stores stores the last followers in a replicant array and checks to see if the follower is NOT in that array. If it is not, triggers a new message "newFollower".

I'm concerned that if the array gets too big it will slow down drastically, but this is a good start. 
